### PR TITLE
Make use of the `content-api-models-scala` dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,22 +40,14 @@ releaseProcess := Seq(
   pushChanges
 )
 
-scroogeThriftDependencies in Compile := Seq("content-api-models", "story-packages-model-thrift", "content-atom-model-thrift")
 resolvers += "Guardian GitHub Repository" at "http://guardian.github.io/maven/repo-releases"
 
 libraryDependencies ++= Seq(
-  "com.gu" % "content-api-models" % "9.3",
+  "com.gu" % "content-api-models-scala" % "9.9",
   "com.amazonaws" % "amazon-kinesis-client" % "1.6.3",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.77",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
-  "org.apache.thrift" % "libthrift" % "0.9.1",
-  "com.twitter" %% "scrooge-core" % "4.6.0")
-
-
-// See: https://github.com/twitter/scrooge/issues/199
-scroogeThriftSources in Compile ++= {
-  (scroogeUnpackDeps in Compile).value.flatMap { dir => (dir ** "*.thrift").get }
-}
+  "com.twitter" %% "scrooge-core" % "4.5.0")
 
 initialize := {
   val _ = initialize.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,3 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
 resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
-
-resolvers += "twitter-repo" at "https://maven.twttr.com"
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.6.0")


### PR DESCRIPTION
By making use of the `content-api-models-scala` dependency we no longer have to be responsible for building the Scrooge generated classes based on the content-api-models ourselves.