### PR TITLE
Make the API of PublicationLogic more consistent

### DIFF
--- a/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
@@ -30,8 +30,8 @@ class ContentApiEventProcessor(override val checkpointInterval: Duration, overri
       case EventType.Update | EventType.RetrievableUpdate =>
         event.payload.foreach { payload =>
           payload match {
-            case content: EventPayload.Content => publicationLogic.contentUpdate(content.content)
-            case content: EventPayload.RetrievableContent => publicationLogic.contentRetrievableUpdate(content)
+            case EventPayload.Content(content) => publicationLogic.contentUpdate(content)
+            case EventPayload.RetrievableContent(content) => publicationLogic.contentRetrievableUpdate(content)
             case UnknownUnionField(e) => logger.warn(s"Received an unknown event payload $e. You should possibly consider updating")
           }
         }

--- a/src/main/scala/com/gu/contentapi/firehose/client/PublicationLogic.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/client/PublicationLogic.scala
@@ -1,7 +1,7 @@
 package com.gu.contentapi.firehose.client
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.crier.model.event.v1.EventPayload.RetrievableContent
+import com.gu.crier.model.event.v1.RetrievableContent
 
 /**
  * Client interface to implement for providing logic to handle various types of events.


### PR DESCRIPTION
and avoid exposing the payload wrapper in the API, as it's just an artifact of how Scrooge represents the union type.