### PR TITLE
SDK v2 Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# v0.3.0
+
+- Updates library dependencies to AWS SDK v2 and AWS KCL v2
+- Updates Scrooge to 21.1.0 from 19.3.0
+- Add build for Scala 2.13
+- Remove support for Scala 2.11, as Scrooge has dropped support for that
+- Update content API data models
+- Support new `EventPayload.DeletedContent` event. This introduces a new `contentDelete` method in the client's processor that must be implemented

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ scalaVersion := "2.12.17"
 crossScalaVersions := Seq(scalaVersion.value, "2.13.8")
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-release:8", "-Xfatal-warnings")
 Compile / doc / scalacOptions  := Nil
-credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 
 releaseCrossBuild := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtrelease.ReleaseStateTransformations._
 name:= "content-api-firehose-client"
 organization := "com.gu"
 scalaVersion := "2.12.17"
-crossScalaVersions := Seq(scalaVersion.value, "2.13.9")
+crossScalaVersions := Seq(scalaVersion.value, "2.13.8")
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-release:8", "-Xfatal-warnings")
 Compile / doc / scalacOptions  := Nil
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name:= "content-api-firehose-client"
 organization := "com.gu"
 scalaVersion := "2.12.17"
 crossScalaVersions := Seq(scalaVersion.value, "2.13.9")
-scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-release:8", "-Xfatal-warnings")
 Compile / doc / scalacOptions  := Nil
 
 releaseCrossBuild := true

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ scalaVersion := "2.12.17"
 crossScalaVersions := Seq(scalaVersion.value, "2.13.9")
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-release:8", "-Xfatal-warnings")
 Compile / doc / scalacOptions  := Nil
+credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 
 releaseCrossBuild := true
 
@@ -30,11 +31,16 @@ scmInfo := Some(ScmInfo(
 
 publishTo := Some(
   if (isSnapshot.value)
-    Opts.resolver.sonatypeSnapshots
+    Opts.resolver.sonatypeOssSnapshots.head
   else
     Opts.resolver.sonatypeStaging
 )
 
+ThisBuild / publishMavenStyle := true
+ThisBuild / pomIncludeRepository := { _ => false }
+
+releaseCrossBuild := true
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
 releaseProcess := Seq(
   checkSnapshotDependencies,
   inquireVersions,

--- a/build.sbt
+++ b/build.sbt
@@ -58,9 +58,3 @@ libraryDependencies ++= Seq(
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")
-
-//initialize := {
-//  val _ = initialize.value
-//  assert(sys.props("java.specification.version") == "1.8",
-//    "Java 8 is required for this project.")
-//}

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import sbtrelease.ReleaseStateTransformations._
 
 name:= "content-api-firehose-client"
 organization := "com.gu"
-scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.11.12", scalaVersion.value)
+scalaVersion := "2.12.17"
+crossScalaVersions := Seq(scalaVersion.value, "2.13.9")
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
 Compile / doc / scalacOptions  := Nil
 
@@ -53,15 +53,14 @@ releaseProcess := Seq(
 resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/repo-releases"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "14.1",
-  "com.gu" %% "thrift-serializer" % "4.0.0",
-  "com.amazonaws" % "amazon-kinesis-client" % "1.9.1",
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.378",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
-  "com.twitter" %% "scrooge-core" % "19.3.0")
+  "com.gu" %% "content-api-models-scala" % "17.3.0",
+  "com.gu" %% "thrift-serializer" % "5.0.0-SNAPSHOT",
+  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "com.twitter" %% "scrooge-core" % "21.1.0")
 
-initialize := {
-  val _ = initialize.value
-  assert(sys.props("java.specification.version") == "1.8",
-    "Java 8 is required for this project.")
-}
+//initialize := {
+//  val _ = initialize.value
+//  assert(sys.props("java.specification.version") == "1.8",
+//    "Java 8 is required for this project.")
+//}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,3 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")

--- a/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
@@ -18,7 +18,7 @@ class ContentApiFirehoseConsumer(
   val streamListener: StreamListener,
   val filterProductionMonitoring: Boolean = false) extends KinesisStreamReader {
 
-  val eventProcessorFactory = new ShardRecordProcessorFactory {
+  lazy val eventProcessorFactory = new ShardRecordProcessorFactory {
     override def shardRecordProcessor(): ShardRecordProcessor = new ContentApiEventProcessor(filterProductionMonitoring, kinesisStreamReaderConfig.checkpointInterval, kinesisStreamReaderConfig.maxCheckpointBatchSize, streamListener)
   }
 }

--- a/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
@@ -4,10 +4,10 @@ import com.gu.contentapi.firehose.client.StreamListener
 import com.gu.contentapi.firehose.kinesis.{ KinesisStreamReader, KinesisStreamReaderConfig, SingleEventProcessor }
 import com.gu.crier.model.event.v1.EventPayload.{ Atom, UnknownUnionField }
 import com.gu.crier.model.event.v1.EventType.EnumUnknownEventType
-import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType, ItemType }
+import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType }
 import com.twitter.scrooge.ThriftStructCodec
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.kinesis.lifecycle.{ ShutdownInput, ShutdownReason }
+import software.amazon.kinesis.lifecycle.{ ShutdownReason }
 import software.amazon.kinesis.processor.{ ShardRecordProcessor, ShardRecordProcessorFactory }
 
 import scala.concurrent.duration._
@@ -33,6 +33,7 @@ class ContentApiEventProcessor(filterProductionMonitoring: Boolean, override val
           case EventPayload.Content(content) => streamListener.contentUpdate(content)
           case EventPayload.RetrievableContent(content) => streamListener.contentRetrievableUpdate(content)
           case EventPayload.Atom(atom) => streamListener.atomUpdate(atom)
+          case EventPayload.DeletedContent(content) => streamListener.contentDelete(content)
           case UnknownUnionField(e) => logger.warn(s"Received an unknown event payload $e. You should possibly consider updating")
         }
 

--- a/src/main/scala/com/gu/contentapi/firehose/client/PublicationLogic.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/client/PublicationLogic.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.firehose.client
 
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentatom.thrift.Atom
-import com.gu.crier.model.event.v1.RetrievableContent
+import com.gu.crier.model.event.v1.{ DeletedContent, RetrievableContent }
 
 /**
  * Client interface to implement for providing logic to handle various types of events.
@@ -25,6 +25,12 @@ trait StreamListener {
    * @param content
    */
   def contentRetrievableUpdate(content: RetrievableContent): Unit
+
+  /**
+   * When content is deleted on the Guardian an update event will be sent to the events stream.
+   * @param content
+   */
+  def contentDelete(content: DeletedContent): Unit
 
   /**
    * When content is removed from the Guardian a `takedown` event will be sent to the events stream. We expect all

--- a/src/main/scala/com/gu/contentapi/firehose/kinesis/KinesisStreamReader.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/kinesis/KinesisStreamReader.scala
@@ -1,16 +1,21 @@
 package com.gu.contentapi.firehose.kinesis
 
 import java.util.concurrent.Executors
-import com.amazonaws.services.kinesis.metrics.impl.NullMetricsFactory
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import java.util.UUID
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{ InitialPositionInStream, KinesisClientLibConfiguration, Worker }
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory
+import software.amazon.kinesis.common.{ ConfigsBuilder, InitialPositionInStream, KinesisClientUtil }
+import software.amazon.kinesis.coordinator.Scheduler
+import software.amazon.kinesis.processor.ShardRecordProcessorFactory
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 
 trait KinesisStreamReader {
-
+  val credentialsProvider: AwsCredentialsProvider
   val kinesisStreamReaderConfig: KinesisStreamReaderConfig
-  protected val eventProcessorFactory: IRecordProcessorFactory
+  protected val eventProcessorFactory: ShardRecordProcessorFactory
 
   /* only applies when there are no checkpoints */
   val initialPosition = InitialPositionInStream.TRIM_HORIZON
@@ -18,32 +23,36 @@ trait KinesisStreamReader {
   /* Unique ID for the worker thread */
   private val workerId = UUID.randomUUID().toString
 
-  private lazy val config =
-    new KinesisClientLibConfiguration(
-      kinesisStreamReaderConfig.applicationName,
-      kinesisStreamReaderConfig.streamName,
-      kinesisStreamReaderConfig.kinesisCredentialsProvider,
-      kinesisStreamReaderConfig.dynamoCredentialsProvider,
-      null,
-      workerId)
-      .withInitialPositionInStream(initialPosition)
-      .withRegionName(kinesisStreamReaderConfig.awsRegion)
-      .withMaxRecords(kinesisStreamReaderConfig.maxRecords)
-      .withIdleTimeBetweenReadsInMillis(kinesisStreamReaderConfig.idleTimeBetweenReadsInMillis)
+  private val kinesisClient = KinesisClientUtil.createKinesisAsyncClient(
+    KinesisAsyncClient.builder()
+      .credentialsProvider(credentialsProvider)
+      .region(Region.of(kinesisStreamReaderConfig.awsRegion)))
 
-  /* Create a worker, which will in turn create one or more EventProcessors */
-  lazy val worker: Worker = new Worker.Builder()
-    .metricsFactory(new NullMetricsFactory())
-    .execService(threadPool)
-    .config(config)
-    .recordProcessorFactory(eventProcessorFactory)
-    .build()
+  private val dynamoClient = DynamoDbAsyncClient.builder().credentialsProvider(credentialsProvider).region(Region.of(kinesisStreamReaderConfig.awsRegion)).build()
+  private val cwClient = CloudWatchAsyncClient.builder().credentialsProvider(credentialsProvider).region(Region.of(kinesisStreamReaderConfig.awsRegion)).build()
+  private val configsBuilder = new ConfigsBuilder(
+    kinesisStreamReaderConfig.streamName,
+    kinesisStreamReaderConfig.applicationName,
+    kinesisClient,
+    dynamoClient,
+    cwClient,
+    workerId,
+    eventProcessorFactory)
+
+  lazy val scheduler: Scheduler = new Scheduler(
+    configsBuilder.checkpointConfig(),
+    configsBuilder.coordinatorConfig(),
+    configsBuilder.leaseManagementConfig(),
+    configsBuilder.lifecycleConfig(),
+    configsBuilder.metricsConfig(),
+    configsBuilder.processorConfig(),
+    configsBuilder.retrievalConfig())
 
   private lazy val threadPool = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(s"${getClass.getSimpleName}-$workerId-thread-%d").build())
 
   /* Start the worker in a new thread. It will run forever */
   private lazy val workerThread =
-    new Thread(worker, s"${getClass.getSimpleName}-$workerId")
+    new Thread(scheduler, s"${getClass.getSimpleName}-$workerId")
 
   def start(): Thread = {
     workerThread.start()
@@ -51,7 +60,7 @@ trait KinesisStreamReader {
   }
 
   def shutdown(): Unit = {
-    worker.shutdown()
+    scheduler.shutdown()
     threadPool.shutdown()
   }
 

--- a/src/main/scala/com/gu/contentapi/firehose/kinesis/KinesisStreamReaderConfig.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/kinesis/KinesisStreamReaderConfig.scala
@@ -1,6 +1,7 @@
 package com.gu.contentapi.firehose.kinesis
 
-import com.amazonaws.auth.AWSCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+
 import scala.concurrent.duration._
 
 case class KinesisStreamReaderConfig(
@@ -9,8 +10,8 @@ case class KinesisStreamReaderConfig(
   stage: String,
   mode: String,
   suffix: Option[String],
-  kinesisCredentialsProvider: AWSCredentialsProvider,
-  dynamoCredentialsProvider: AWSCredentialsProvider,
+  kinesisCredentialsProvider: AwsCredentialsProvider,
+  dynamoCredentialsProvider: AwsCredentialsProvider,
   awsRegion: String,
   checkpointInterval: Duration = 30.second,
   maxCheckpointBatchSize: Int = 20,

--- a/src/main/scala/com/gu/contentapi/firehose/kinesis/SingleEventProcessor.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/kinesis/SingleEventProcessor.scala
@@ -1,20 +1,21 @@
 package com.gu.contentapi.firehose.kinesis
 
-import com.amazonaws.services.kinesis.model.Record
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.{ IRecordProcessor, IRecordProcessorCheckpointer }
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
 import com.gu.thrift.serializer.ThriftDeserializer
 import com.typesafe.scalalogging.LazyLogging
 import com.twitter.scrooge.{ ThriftStruct, ThriftStructCodec }
+import software.amazon.kinesis.lifecycle.ShutdownReason
+import software.amazon.kinesis.lifecycle.events.{ InitializationInput, LeaseLostInput, ProcessRecordsInput, ShardEndedInput, ShutdownRequestedInput }
+import software.amazon.kinesis.processor.{ Checkpointer, RecordProcessorCheckpointer, ShardRecordProcessor }
+import software.amazon.kinesis.retrieval.kpl.Messages.Record
+
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong }
 import java.util.{ List => JList }
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.concurrent.Await
-import scala.util.{ Try, Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
 abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
-  extends IRecordProcessor
+  extends ShardRecordProcessor
   with LazyLogging {
 
   val checkpointInterval: Duration
@@ -26,14 +27,14 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
   private[this] val lastCheckpointedAt = new AtomicLong(System.nanoTime())
   private[this] val recordsProcessedSinceCheckpoint = new AtomicInteger()
 
-  override def initialize(shardId: String): Unit = {
-    this.shardId = shardId
+  override def initialize(input: InitializationInput): Unit = {
+    this.shardId = input.shardId()
     logger.info(s"Initialized an event processor for shard $shardId")
   }
 
-  override def processRecords(records: JList[Record], checkpointer: IRecordProcessorCheckpointer): Unit = {
-    val events = records.asScala.flatMap { record =>
-      val buffer = record.getData.array
+  override def processRecords(input: ProcessRecordsInput): Unit = {
+    val events = input.records().asScala.flatMap { record =>
+      val buffer = record.data()
       val op = ThriftDeserializer.deserialize(buffer)
       op match {
         case Success(event) => Some(event)
@@ -50,7 +51,7 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
     recordsProcessedSinceCheckpoint.addAndGet(events.size)
 
     if (shouldCheckpointNow) {
-      checkpoint(checkpointer)
+      checkpoint(input.checkpointer())
     }
   }
 
@@ -61,7 +62,7 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
     recordsProcessedSinceCheckpoint.get() >= maxCheckpointBatchSize ||
       lastCheckpointedAt.get() < System.nanoTime() - checkpointInterval.toNanos
 
-  private def checkpoint(checkpointer: IRecordProcessorCheckpointer) = {
+  private def checkpoint(checkpointer: RecordProcessorCheckpointer) = {
     /* Store our latest position in the stream */
     checkpointer.checkpoint()
 
@@ -70,14 +71,27 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
     recordsProcessedSinceCheckpoint.set(0)
   }
 
-  /* This method may be called by KCL, e.g. in case of shard splits/merges */
-  override def shutdown(checkpointer: IRecordProcessorCheckpointer, reason: ShutdownReason): Unit = {
-    if (reason == ShutdownReason.TERMINATE) {
-      checkpointer.checkpoint()
-    }
-    logger.info(s"Shutdown event processor for shard $shardId because $reason")
+  def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
+    logger.info(s"Shutdown event processor for shard $shardId because lease was lost")
+    shutdown(ShutdownReason.LEASE_LOST)
   }
 
+  def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
+    logger.info(s"Shutdown event processor for shard $shardId because the shard ended")
+    shutdown(ShutdownReason.SHARD_END)
+  }
+
+  def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
+    shutdownRequestedInput.checkpointer().checkpoint()
+    logger.info(s"Shutdown event processor for shard $shardId because shutdown was requested")
+    shutdown(ShutdownReason.REQUESTED)
+  }
+
+  /**
+   * Subclass this method if you want to be informed of shutdown events.  The default implementation does nothing.
+   * @param reason ShutdownReason indicating why the shutdown occurred
+   */
+  def shutdown(reason: ShutdownReason): Unit = {}
 }
 
 trait SingleEventProcessor[EventT <: ThriftStruct] extends EventProcessor[EventT] {

--- a/src/main/scala/com/gu/contentapi/firehose/kinesis/SingleEventProcessor.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/kinesis/SingleEventProcessor.scala
@@ -5,12 +5,10 @@ import com.typesafe.scalalogging.LazyLogging
 import com.twitter.scrooge.{ ThriftStruct, ThriftStructCodec }
 import software.amazon.kinesis.lifecycle.ShutdownReason
 import software.amazon.kinesis.lifecycle.events.{ InitializationInput, LeaseLostInput, ProcessRecordsInput, ShardEndedInput, ShutdownRequestedInput }
-import software.amazon.kinesis.processor.{ Checkpointer, RecordProcessorCheckpointer, ShardRecordProcessor }
-import software.amazon.kinesis.retrieval.kpl.Messages.Record
+import software.amazon.kinesis.processor.{ RecordProcessorCheckpointer, ShardRecordProcessor }
 
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong }
-import java.util.{ List => JList }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
@@ -43,7 +41,7 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
           None
         }
       }
-    }
+    }.toSeq //.toSeq is required on Scala 2.13 as the comprehension above gives us a mutable.Buffer which is not directly compatible with Seq.
 
     processEvents(events)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.1-SNAPSHOT"
+ThisBuild / version := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

- Updates library dependencies to AWS SDK v2 and AWS KCL v2; associated syntax changes
- Updates Scrooge to 21.1.0 from 19.3.0
- Add build for Scala 2.13
- Remove support for Scala 2.11, as Scrooge has dropped support for that
- Update content API data models
- Support new `EventPayload.DeletedContent` event. This introduces a new `contentDelete` method in the client's processor that must be implemented

## How to test

- Pull it into your project. You'll need to implement `contentDelete` before it compiles, otherwise changes should be minimal
- Check it on a Scala 2.13 project. Should resolve without any trouble.
- Your dependencies will have changed, this now should only pull in AWS SDK v2 dependencies not v1 dependencies

## How can we measure success?

- No more blockers to 2.13/Java 11 updates
