### PR TITLE
Ag/update for thrift bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name:= "content-api-firehose-client"
 organization := "com.gu"
 scalaVersion := "2.12.17"
 crossScalaVersions := Seq(scalaVersion.value, "2.13.10")
-scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-release:8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-Xfatal-warnings")
 Compile / doc / scalacOptions  := Nil
 
 releaseCrossBuild := true
@@ -56,10 +56,11 @@ releaseProcess := Seq(
 )
 
 resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/repo-releases"
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % "17.3.0",
-  "com.gu" %% "thrift-serializer" % "5.0.0",
+  "com.gu" %% "thrift-serializer" % "5.0.1-SNAPSHOT",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % "17.3.0",
-  "com.gu" %% "thrift-serializer" % "5.0.1-SNAPSHOT",
+  "com.gu" %% "thrift-serializer" % "5.0.2-SNAPSHOT",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % "17.3.0",
-  "com.gu" %% "thrift-serializer" % "5.0.2-SNAPSHOT",
+  "com.gu" %% "thrift-serializer" % "5.0.2",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.1-SNAPSHOT"
+ThisBuild / version := "0.3.3-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.2-SNAPSHOT"
+ThisBuild / version := "0.3.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.3-SNAPSHOT"
+ThisBuild / version := "0.3.5-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Updates the firehose API client to include https://github.com/guardian/thrift-serializer/pull/26, a fix for `ERROR c.g.c.f.ContentApiEventProcessor deserialization of event buffer failed: Received wrong type for field 'payloadId' (expected=STRING, actual=I32).`

This is simply done by updating the library version

## How to test

Just double-check the versions. The actual fix is in the upstream thrift-serializer library and it is tested in CI there

## How can we measure success?

No more of the aforementioned error

## Have we considered potential risks?

n/a
