### PR TITLE
Snyk update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,8 @@ resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/r
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "17.3.0",
+  "com.gu" %% "content-api-models-scala" % "17.5.1",
   "com.gu" %% "thrift-serializer" % "5.0.2",
-  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3",
+  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.8",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")

--- a/build.sbt
+++ b/build.sbt
@@ -64,3 +64,12 @@ libraryDependencies ++= Seq(
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.8",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")
+
+val jacksonVersion = "2.12.7"
+dependencyOverrides ++= Seq(
+  "com.charleskorn.kaml" % "kaml" % "0.53.0",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7.1",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "software.amazon.awssdk" % "netty-nio-client" % "2.20.26",
+)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,2 @@
-version in ThisBuild := "1.0.0-SNAPSHOT"
+ThisBuild / version := "1.0.0"
+ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.5"
+ThisBuild / version := "1.0.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.0-SNAPSHOT"
+version in ThisBuild := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

- Updates dependencies identified as vulnerable
- Updates content models to latest version
- Declaring version 1.0.0, in order to reduce version number confusion. Please strictly observe semantic versioning from now on!

## How to test

This has been tested by building into Pubflow and deploying to CODE.  Publication still Flows :)

## How can we measure success?

A (slightly) more secure environment

## Have we considered potential risks?

Downgrade back to 0.3.5 if you experience problems and contact content-platforms.dev@theguardian.com
