### PR TITLE
Fix 1 high snyk vuln in firehose client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,5 +101,6 @@ dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "software.amazon.awssdk" % "netty-nio-client" % "2.20.26",
   "org.json" % "json" % "20230227",
-  "io.netty" % "netty-handler" % "4.1.93.Final"
+  "io.netty" % "netty-handler" % "4.1.93.Final",
+  "org.xerial.snappy" % "snappy-java" % "1.1.10.1"
 )


### PR DESCRIPTION
## What does this change?

This will fix 1 high vuln : `org.xerial.snappy:snappy-java Denial of Service (DoS)`

## How to test

Not sure how to test, Do I need to generate snapshot as written in Readme file?
Or this dependency override is fine to deploy?
Need to check with team.

I ran `snyk test`, that shows 1 high vuln is fixed by the override.

## How can we measure success?

firehose client should work as expected for all updates and deletes 

## Have we considered potential risks?

If library override should not fail in any existing codebase 
