### PR TITLE
fixing 1 high snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,5 +102,5 @@ dependencyOverrides ++= Seq(
   "software.amazon.awssdk" % "netty-nio-client" % "2.20.26",
   "org.json" % "json" % "20230227",
   "io.netty" % "netty-handler" % "4.1.93.Final",
-  "org.xerial.snappy" % "snappy-java" % "1.1.10.1"
+  "org.xerial.snappy" % "snappy-java" % "1.1.10.4"
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.6-SNAPSHOT"
+ThisBuild / version := "1.0.9-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

`org.xerial.snappy:snappy-java` has got version upgrade (patch upgrade) on which snyk has raised 1 high vulnerability on its older version we own. Hence updated to latest version. (1.10.1 to 1.1.10.4.)

## How to test

Create snapshot version to test in other application that uses firehose client. 
We will test in `pubflow`.

## How can we measure success?

pubflow should work as expected