### PR TITLE
Update netty-handler and netty-codec-http2 versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % "17.5.1",
   "com.gu" %% "thrift-serializer" % "5.0.2",
-  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.0",
+  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.2",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.1.0")
 
@@ -101,6 +101,7 @@ dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "software.amazon.awssdk" % "netty-nio-client" % "2.20.26",
   "org.json" % "json" % "20230227",
-  "io.netty" % "netty-handler" % "4.1.93.Final",
+  "io.netty" % "netty-handler" % "4.1.94.Final",
+  "io.netty" % "netty-codec-http2" % "4.1.94.Final",
   "org.xerial.snappy" % "snappy-java" % "1.1.10.4"
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.9-SNAPSHOT"
+ThisBuild / version := "1.0.10-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Bump a couple of netty dependencies

## How to test

Bump, release a snapshot, test the snapshot build in a client application

## How can we measure success?

If the application functions as expected with the snapshot build, success!

## Have we considered potential risks?

A latent issue may arise due to other dependencies, but as it's a small (patch version) bump, it should be binary compatible so evictions _shouldn't_ break it.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A
