### PR TITLE
Fix inaccurate workflow naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: corretto
           java-version: 11
           cache: sbt
-      - name: Release Snapshot to Sonatype
+      - name: Release Snapshot (prerelease) to Sonatype
         run: |
           VERSION=$(git describe --tags | cut -f2 -d"@")
           if [[ ${VERSION:0:1} == "v" ]] ; then


### PR DESCRIPTION
## What does this change?

- Renames the release workflow file from `release-snapshot.yml` to `release.yml` as that better reflects its functionality.
- Make it explicit that a "prerelease" on Github == "snapshot" on Sonatype / Maven

## How to test

Just check it makes sense to you. No functional changes.

## How can we measure success?

Less confusion, moving towards a standard

## Have we considered potential risks?

n/a

