### PR TITLE
Fix snyk high vuln in commons-compress library 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,5 +52,6 @@ dependencyOverrides ++= Seq(
   "org.json" % "json" % "20231013",
   "io.netty" % "netty-handler" % "4.1.94.Final",      // SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
-  "org.xerial.snappy" % "snappy-java" % "1.1.10.4"
+  "org.xerial.snappy" % "snappy-java" % "1.1.10.4",
+  "org.apache.commons" % "commons-compress" % "1.26.0"
 )


### PR DESCRIPTION
## What does this change?

Affected versions of commons-compress are vulnerable to Infinite loop.
Need to do dependency override for this, this is used under kinesis stream libary.

## How to test

Test preview version of this library in one of its client, pubflow or apple-news. 
those apps should pass tests and runs as expected 
