### PR TITLE
Fix snyk high in ion-java library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,5 +53,6 @@ dependencyOverrides ++= Seq(
   "io.netty" % "netty-handler" % "4.1.94.Final",      // SNYK-JAVA-IONETTY-5725787
   "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
   "org.xerial.snappy" % "snappy-java" % "1.1.10.4",
-  "org.apache.commons" % "commons-compress" % "1.26.0"
+  "org.apache.commons" % "commons-compress" % "1.26.0",
+  "com.amazon.ion" % "ion-java" % "1.10.5"
 )


### PR DESCRIPTION
## What does this change?

Pubflow started showing `ion-java` snyk high vuln under latest firehose client version.
Though firehose-client not showing high vuln in `ion-java` library (transitive dependency under `kinesis-client`)which is strange. 
Trying to put 1.10.5 version of com.amazon.ion as recommended patch to check whether this will work fix pubflow high vuln or not. https://security.snyk.io/vuln/SNYK-JAVA-COMAMAZONION-6143590

## How to test

Make a preview release and test in pubflow to see if this fixes high vuln in it or not.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
