### PR TITLE
Update content-api-models-scala to 20.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/r
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "17.5.1",
+  "com.gu" %% "content-api-models-scala" % "20.1.0",
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.2",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",


### PR DESCRIPTION
This dependency is causing conflicts when trying to update the version of fapi-client used by apple news (to get to a newer version of aws-s3-sdk that no longer depends on ion-java, which has a vulnerability).