### PR TITLE
Fix snyk high vuln in 'ion-java' library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,5 +54,6 @@ dependencyOverrides ++= Seq(
   "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
   "org.xerial.snappy" % "snappy-java" % "1.1.10.4",
   "org.apache.commons" % "commons-compress" % "1.26.0",
-  "com.amazon.ion" % "ion-java" % "1.10.5"
+  "com.amazon.ion" % "ion-java" % "1.10.5",
+  "software.amazon.glue" % "schema-registry-serde" % "1.1.19"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,6 @@ dependencyOverrides ++= Seq(
   "io.netty" % "netty-codec-http2" % "4.1.100.Final", // SNYK-JAVA-IONETTY-5953332
   "org.xerial.snappy" % "snappy-java" % "1.1.10.4",
   "org.apache.commons" % "commons-compress" % "1.26.0",
-  "com.amazon.ion" % "ion-java" % "1.10.5",
-  "software.amazon.glue" % "schema-registry-serde" % "1.1.19"
+  "com.amazon.ion" % "ion-java" % "1.10.5",//overriding until a version of amazon-kinesis-client is available that removes the ion-java vulnerability
+  "software.amazon.glue" % "schema-registry-serde" % "1.1.19" //overriding until a version of amazon-kinesis-client is available that removes the ion-java vulnerability
 )


### PR DESCRIPTION
## What does this change?

We tried before the patch recommended by Snyk for `ion-java` still issue is existing hence trying to override kinesis's transitive dependency this time.

<img width="1661" alt="image" src="https://github.com/guardian/content-api-firehose-client/assets/17780995/cfd090e9-fc6d-4462-ae8c-17fbc526ed4a">

## How to test

-Run `snyk test`
-Making preview release and try on `pubflow` (`pubflow` also have this high vuln existing so chosen it to check both at same time)

## How can we measure success?

-`snyk test` -  no more high vuln is listed after running it.
- Need to check it on `pubflow`

(In progress)

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
