### PR TITLE
Update CAPI models dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/r
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "20.1.0",
+  "com.gu" %% "content-api-models-scala" % "22.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.2",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",


### PR DESCRIPTION

## What does this change?

Updates CAPI models to the latest, 22.0.0.  This should bring in e.g. recipes and schemaorg and is required for AN not to throw errors when coming across content with elements in it.

## How to test

- There should be an element type for recipes

## How can we measure success?

Able to fix AN
