### PR TITLE
bump and test content-api-model version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/r
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "22.0.0",
+  "com.gu" %% "content-api-models-scala" % "23.0.0-PREVIEW.dbbump-and-test-content-entity-version.2024-03-27T0934.cbc6ec49", //TODO- to change to prod release
   "com.gu" %% "thrift-serializer" % "5.0.5",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.6",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",


### PR DESCRIPTION
This will test preview release of [content-api-model](https://github.com/guardian/content-api-models/actions/runs/8449574601) that has got content-entity latest release in it.

## How to test

Make a preview release and test in clients consuming this library, we will try either in `apple-news` or `pubflow`

## How can we measure success?

Application should compile fine with no version conflicts and should run fine with no errors.