### PR TITLE
Bump CAPI models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ resolvers += "Guardian GitHub Repository" at "https://guardian.github.io/maven/r
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "24.0.0",
+  "com.gu" %% "content-api-models-scala" % "25.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.5",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.6",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",


### PR DESCRIPTION
This will allow us to use the newer models in Apple News without introducing a binary incompatibility