### PR TITLE
Upgrade Jackson version to fix high vuln

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ resolvers ++= Resolver.sonatypeOssRepos("releases")
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % "25.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.5",
-  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.5.6",
+  "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.12.0")
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
 val jacksonVersion = "2.17.2"
 dependencyOverrides ++= Seq(
   "com.charleskorn.kaml" % "kaml" % "0.53.0",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7.1",
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "software.amazon.awssdk" % "netty-nio-client" % "2.20.26",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.12.0")
 
-val jacksonVersion = "2.12.7"
+val jacksonVersion = "2.17.2"
 dependencyOverrides ++= Seq(
   "com.charleskorn.kaml" % "kaml" % "0.53.0",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7.1",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades the Jackson version due to a high priority security vulnerability.

## How to test

As this is a library, it needs a client application to test. I tried it with [pubflow](https://github.com/guardian/pubflow/tree/pmr/firehose-client-preview-release) on `CODE` and it seems to work fine (i.e. it boots and displays updates to content).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

This should be unnoticable.

## Have we considered potential risks?

Should be OK as it will involve releasing a new version.