### PR TITLE
Belated changes for KCL v3 migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,6 @@ crossScalaVersions := Seq(scalaVersion.value, "2.13.15")
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-Xfatal-warnings", "-release:11")
 Compile / doc / scalacOptions  := Nil
 
-releaseCrossBuild := true
-
 enablePlugins(plugins.JUnitXmlReportPlugin)
 Test / testOptions +=
   Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
@@ -17,10 +15,8 @@ Test / testOptions +=
 organization := "com.gu"
 licenses := Seq(License.Apache2)
 
-releaseCrossBuild := true
-
 releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
-
+releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,

--- a/src/main/scala/com/gu/contentapi/firehose/kinesis/KinesisStreamReader.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/kinesis/KinesisStreamReader.scala
@@ -1,14 +1,15 @@
 package com.gu.contentapi.firehose.kinesis
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import com.gu.contentapi.firehose.kinesis.KinesisStreamReader.{ checkApiAccess, kinesisClientFor }
+import com.gu.contentapi.firehose.kinesis.KinesisStreamReader.{checkApiAccess, kinesisClientFor}
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.kinesis.common.KinesisClientUtil.createKinesisAsyncClient
-import software.amazon.kinesis.common.{ ConfigsBuilder, InitialPositionInStream, KinesisRequestsBuilder }
+import software.amazon.kinesis.common.{ConfigsBuilder, InitialPositionInStream, KinesisRequestsBuilder}
+import software.amazon.kinesis.coordinator.CoordinatorConfig.ClientVersionConfig.CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2X
 import software.amazon.kinesis.coordinator.Scheduler
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory
 
@@ -57,7 +58,7 @@ trait KinesisStreamReader {
 
   lazy val scheduler: Scheduler = new Scheduler(
     configsBuilder.checkpointConfig(),
-    configsBuilder.coordinatorConfig(),
+    configsBuilder.coordinatorConfig().clientVersionConfig(CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2X),
     configsBuilder.leaseManagementConfig(),
     configsBuilder.lifecycleConfig(),
     configsBuilder.metricsConfig(),


### PR DESCRIPTION
See:

* https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html
* https://github.com/guardian/content-api-firehose-client/releases/tag/v1.0.26
* https://github.com/guardian/content-api-firehose-client/pull/52 - which did the original update to KCL v3, but without seeing the migration doc first!