### PR TITLE
Phasers on stun: Unnecessary but fun concurrency synchronisation for KCL v3

### DIFF
--- a/src/main/scala/com/gu/contentapi/firehose/kinesis/SingleEventProcessor.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/kinesis/SingleEventProcessor.scala
@@ -3,12 +3,15 @@ package com.gu.contentapi.firehose.kinesis
 import com.gu.thrift.serializer.ThriftDeserializer
 import com.typesafe.scalalogging.LazyLogging
 import com.twitter.scrooge.{ ThriftStruct, ThriftStructCodec }
+import software.amazon.kinesis.exceptions.{ InvalidStateException, ShutdownException }
 import software.amazon.kinesis.lifecycle.ShutdownReason
 import software.amazon.kinesis.lifecycle.events.{ InitializationInput, LeaseLostInput, ProcessRecordsInput, ShardEndedInput, ShutdownRequestedInput }
 import software.amazon.kinesis.processor.{ RecordProcessorCheckpointer, ShardRecordProcessor }
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
+import java.util.concurrent.{ Phaser, TimeoutException }
+import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong }
 import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
@@ -18,6 +21,7 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
   extends ShardRecordProcessor
   with LazyLogging {
 
+  private val ongoingProcessRecordCallsPhaser = new Phaser(1) // allow 1 'await' in shutdownRequested()
   val checkpointInterval: Duration
   val maxCheckpointBatchSize: Int
 
@@ -33,6 +37,7 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
   }
 
   override def processRecords(input: ProcessRecordsInput): Unit = {
+    ongoingProcessRecordCallsPhaser.register() // graceful shutdown should wait for us to complete this work
     val events = input.records().asScala.flatMap { record =>
       val buffer = record.data()
       val op = ThriftDeserializer.deserialize(buffer)
@@ -50,6 +55,7 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
     }.toSeq //.toSeq is required on Scala 2.13 as the comprehension above gives us a mutable.Buffer which is not directly compatible with Seq.
 
     processEvents(events)
+    ongoingProcessRecordCallsPhaser.arriveAndDeregister() // it's no longer necessary for any shutdown to wait for us
 
     /* increment the record counter */
     recordsProcessedSinceCheckpoint.addAndGet(events.size)
@@ -86,7 +92,21 @@ abstract class EventProcessor[EventT <: ThriftStruct: ThriftStructCodec]
   }
 
   def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
-    shutdownRequestedInput.checkpointer().checkpoint()
+    try {
+      val ongoingCalls = ongoingProcessRecordCallsPhaser.getUnarrivedParties - 1
+      if (ongoingCalls > 0)
+        logger.info(s"Shutdown requested but waiting for processRecords() to complete - ongoingCalls=$ongoingCalls")
+
+      // Ensure that all records we've received have been processed before we call checkpoint and exit
+      Try(ongoingProcessRecordCallsPhaser.awaitAdvanceInterruptibly(ongoingProcessRecordCallsPhaser.arrive(), 10, SECONDS)).recover {
+        case e: TimeoutException => logger.error("Timeout while waiting for processRecords() to complete", e)
+      }
+      logger.info("Scheduler is shutting down, checkpointing.")
+      shutdownRequestedInput.checkpointer().checkpoint()
+    } catch {
+      case e @ (_: ShutdownException | _: InvalidStateException) =>
+        logger.error("Exception while checkpointing at requested shutdown. Giving up.", e)
+    }
     logger.info(s"Shutdown event processor for shard $shardId because shutdown was requested")
     shutdown(ShutdownReason.REQUESTED)
   }


### PR DESCRIPTION
I wrote this code when working on https://github.com/guardian/content-api-firehose-client/pull/56 - the slightly ambiguous wording in the migration notes for KCL v3 suggested to me that this concurrency synchronisation might be necessary, but later I grew uncertain and performed a bunch of tests that confirmed it was indeed _not_ necessary - so this code is redundant, but also quite cool, because **pew-pew** - it uses 🔫  _Phasers !_ 🔫

These aren't Star Trek phasers, sadly. These Phasers are a [Java concurrency](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/package-summary.html#synchronizers-heading) primitive, like [Semaphore](https://en.wikipedia.org/wiki/Semaphore_(programming)) or `CountDownLatch`.

## Why did I think this synchronisation might be necessary?

KCL v3 Migration [Step 4](https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html#kcl-migration-from-2-3-best-practice) regards "Graceful lease handoff", and says:

> If you are performing any asynchronous processing, make sure that all delivered records to the downstream were processed before invoking checkpointing.

I wasn't _sure_ how to interpret this, but I _thought_ it was possible for a call to `processRecords()` (invoked by [`software.amazon.kinesis.lifecycle.ProcessTask`](https://github.com/awslabs/amazon-kinesis-client/blob/854d99da52f4efb83d273884098945e9708508ee/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java#L181)) to be ongoing while `shutdownRequested()` is called (invoked by [`software.amazon.kinesis.lifecycle.ShutdownNotificationTask`](https://github.com/awslabs/amazon-kinesis-client/blob/854d99da52f4efb83d273884098945e9708508ee/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownNotificationTask.java#L50)).

If that were the case, we would want to make sure we've finished our processing work in `processRecords()` before we checkpoint in `shutdownRequested()`, while being conscious that it could be occurring in a different thread.
