### PR TITLE
Bump CAPI models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ releaseProcess := Seq[ReleaseStep](
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "26.0.0",
+  "com.gu" %% "content-api-models-scala" % "29.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.7",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "3.0.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",


### PR DESCRIPTION
This will allow us to use the newer models in Apple News without introducing a binary incompatibility