### PR TITLE
Remove usage of `dependencyOverrides` & superfluous explicit dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion
 )
 
-resolvers ++= Resolver.sonatypeOssRepos("releases")
+val jacksonVersion = "2.17.2"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % "37.0.0",
@@ -36,24 +36,34 @@ libraryDependencies ++= Seq(
   "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.twitter" %% "scrooge-core" % "21.12.0",
-  "at.yawk.lz4" % "lz4-java" % "1.10.4", // https://github.com/advisories/GHSA-cmp6-m4wj-q63q
-  "org.scalatest" %% "scalatest" % "3.2.19" % Test
+  "at.yawk.lz4" % "lz4-java" % "1.10.4", // Necessary while the ExclusionRule for org.lz4:lz4-java is necessary
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
 ) ++ Seq("aws-json-protocol", "kinesis").map(artifact => "software.amazon.awssdk" % artifact % "2.29.47")
 
 excludeDependencies ++= Seq(
+  /**
+   * This ExclusionRule for `org.lz4:lz4-java` (vulnerability: https://github.com/advisories/GHSA-cmp6-m4wj-q63q)
+   * is necessary while our dependencies would still pull it in. The replacement for the dependency is
+   * `at.yawk.lz4:lz4-java`, a fork that still uses the same class names, eg [[net.jpountz.lz4.LZ4BlockInputStream]].
+   *
+   * As of KCL v3.2.1, **without this ExclusionRule**:
+   *
+   * % sbt "whatDependsOn org.lz4 lz4-java"
+   * [info] org.lz4:lz4-java:1.8.0
+   * [info]   +-org.apache.kafka:kafka-clients:3.6.1
+   * [info]     +-software.amazon.glue:schema-registry-serde:1.1.24
+   * [info]       +-software.amazon.kinesis:amazon-kinesis-client:3.2.1
+   * [info]         +-com.gu:content-api-firehose-client_2.12:1.0.32-SNAPSHOT [S]
+   *
+   * Note, KCL v3.3.0 & above already perform the exclusion and replacement with `at.yawk.lz4:lz4-java`
+   * for us.
+   */
   ExclusionRule(
     organization = "org.lz4", // https://github.com/advisories/GHSA-cmp6-m4wj-q63q
     name = "lz4-java"
   )
-)
-
-val jacksonVersion = "2.17.2"
-dependencyOverrides ++= Seq(
-  "com.charleskorn.kaml" % "kaml" % "0.53.0",
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-  "org.json" % "json" % "20231013",
-  "org.xerial.snappy" % "snappy-java" % "1.1.10.4",
-  "org.apache.commons" % "commons-compress" % "1.26.0"
 )


### PR DESCRIPTION
Changes in this PR:

* https://github.com/guardian/maintaining-scala-projects/issues/20 - because `dependencyOverrides` _does not propagate_ to consuming projects, the `dependencyOverrides` settings would not have had any affect on the dependencies used in consuming projects (eg [`guardian/apple-news`](https://github.com/guardian/apple-news)), leading to a duplication of effort in those consuming projects like https://github.com/guardian/apple-news/pull/257.  Using `libraryDependencies` here means those settings are unnecessary elsewhere - and do not later prompt Scala Steward PRs, etc.
* For those explicitly stated dependencies under `dependencyOverrides`, only the ones that are still _useful_ were copied to `libraryDependencies`. That turned out to be just the Jackson dependencies, all other explicit dependencies are now superfluous with KCL v3.2.1 and so have been removed.
* https://github.com/guardian/maintaining-scala-projects/issues/11

## Removed superfluous explicit dependencies

These are not _directly_ used by the `content-api-firehose-client` project, and were only ever explicitly declared in order to get versions that had dependency vulnerabilities fixed.


### Already pulled in by our current version of the KCL

KCL v3.2.1 already pulls in versions of these dependencies that are equivalent or newer:

* ["com.charleskorn.kaml" % "kaml"](https://github.com/guardian/content-api-firehose-client/pull/94#discussion_r3080565797)
* ["org.json" % "json"](https://github.com/guardian/content-api-firehose-client/pull/94#discussion_r3080553819)
* ["org.xerial.snappy" % "snappy-java"](https://github.com/guardian/content-api-firehose-client/pull/94#discussion_r3080545877)


### No longer used by our current version of the KCL

The KCL no longer uses this dependency:

* ["org.apache.commons" % "commons-compress"](https://github.com/guardian/content-api-firehose-client/pull/94#discussion_r3080577995)
