### PR TITLE
Fix automatic-version-numbering: use `fromAssessedCompatibilityWithLatestRelease`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ Test / testOptions +=
 organization := "com.gu"
 licenses := Seq(License.Apache2)
 
-releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
+releaseVersion := ReleaseVersion.fromAssessedCompatibilityWithLatestRelease().value
 releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,


### PR DESCRIPTION
* https://github.com/guardian/gha-scala-library-release-workflow/issues/81

For Single-Module projects like this one, we need to use:

```
ReleaseVersion.fromAssessedCompatibilityWithLatestRelease()
```

...rather than:

```
ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease()
```

...otherwise automatic-version-numbering just doesn't work, and only does patch-number increments 😢 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
