### PR TITLE
Bump CAPI model to include new video captions field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ releaseProcess := Seq[ReleaseStep](
 val jacksonVersion = "2.17.2"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "37.0.0",
+  // "com.gu" %% "content-api-models-scala" % "37.0.0",
+  "com.gu" %% "content-api-models-scala" % "38.0.0-PREVIEW.rjr-add-new-caption-field-to-capi-model.2026-04-08T1528.c2707d49",
   "com.gu" %% "thrift-serializer" % "5.0.7",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ releaseProcess := Seq[ReleaseStep](
 val jacksonVersion = "2.17.2"
 
 libraryDependencies ++= Seq(
-  // "com.gu" %% "content-api-models-scala" % "37.0.0",
-  "com.gu" %% "content-api-models-scala" % "38.0.0-PREVIEW.rjr-add-new-caption-field-to-capi-model.2026-04-08T1528.c2707d49",
+  "com.gu" %% "content-api-models-scala" % "39.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.7",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",

--- a/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
+++ b/src/main/scala/com/gu/contentapi/firehose/ContentApiFirehoseConsumer.scala
@@ -1,16 +1,16 @@
 package com.gu.contentapi.firehose
 
 import com.gu.contentapi.firehose.client.StreamListener
-import com.gu.contentapi.firehose.kinesis.{KinesisStreamReader, KinesisStreamReaderConfig, SingleEventProcessor}
+import com.gu.contentapi.firehose.kinesis.{ KinesisStreamReader, KinesisStreamReaderConfig, SingleEventProcessor }
 import com.gu.crier.model.event.v1.EventPayload.UnknownUnionField
 import com.gu.crier.model.event.v1.EventType.EnumUnknownEventType
-import com.gu.crier.model.event.v1.{Event, EventPayload, EventType}
+import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType }
 import com.twitter.scrooge.ThriftStructCodec
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.kinesis.coordinator.CoordinatorConfig
 import software.amazon.kinesis.coordinator.CoordinatorConfig.ClientVersionConfig
 import software.amazon.kinesis.lifecycle.ShutdownReason
-import software.amazon.kinesis.processor.{ShardRecordProcessor, ShardRecordProcessorFactory}
+import software.amazon.kinesis.processor.{ ShardRecordProcessor, ShardRecordProcessorFactory }
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
## What does this change?
Composer users need an easier way to update captions for video atoms. The current process of updating them in MAM is laborious and prevents us from showing different captions for the same video on different articles, which is sometimes helpful.

The work in this PR is part of a chain of PRs to add a new `caption` field to the atom editor in Composer. This field should:
- Default to the Media atom's `title` value, set in the Media Atom Maker tool
- Be editable within Composer
- Allow users to clear the field, which would remove the caption entirely from videos used in an article (including standfirst videos)

See the [Rethink media atom captions in Composer](https://github.com/guardian/articles-and-publishing/issues/351) issue (in the Arts&Pubs project) for further details

- [flexible-model](https://github.com/guardian/flexible-model/pull/92) [includes release] - testing in CODE complete
- [flexible-content](https://github.com/guardian/flexible-content/pull/6451) - testing in CODE complete
- [content-api-models](https://github.com/guardian/content-api-models/pull/296) [includes release] - testing in CODE complete
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3330) - testing in CODE complete
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3331) - testing in CODE complete
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3332)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/478) [includes release]
- [content-api-firehose-client](https://github.com/guardian/content-api-firehose-client/pull/96) [includes release] **← ← ← We are here**
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/391) [includes release]
- [frontend](https://github.com/guardian/frontend/pull/28728)
- [dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/15717)
- [apple-news](https://github.com/guardian/apple-news/pull/578)

### Testing

- All PRs in the chain are expected to pass local testing requirements specific to their repo.
- All PRs in the chain will need to pass toolchain and CI tests required by their repo when pushing the branch to remote.

[Testing plan document](https://docs.google.com/document/d/1yXy4sb4_ZJvOUVzpUmWHC0vlIoiyYY9KYdPX1VIA94w/edit?tab=t.0)

### Deployment
Some PRs include model pre-releases. Before deploying to PROD, these pre-releases will need to become full releases, and code in affected PRs updated to reflect these changes.

TODO: come up with an appropriate sequencing for merging and closing PRs. The PRs do not need to all be deployed at the same time, but some - such as those requiring associated releases - need to be performed before others.
TODO: complete the description for the purpose of this PR

---

Note: we need to do work here to try and fix a version clash in a similar PR in the `apple-news` repo
<img width="898" height="380" alt="Screenshot 2026-04-15 at 14 22 02" src="https://github.com/user-attachments/assets/199ac320-51c4-4b36-a56a-ce6e0ad6907f" />
