### PR TITLE
Bump CAPI models to 44.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ releaseProcess := Seq[ReleaseStep](
 val jacksonVersion = "2.17.2"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "41.0.0",
+  "com.gu" %% "content-api-models-scala" % "44.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.7",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.6",


### PR DESCRIPTION
## What does this change?

Bumps CAPI models to 44.0.0.

## How has this change been tested?

- [x] Compiles locally
- [x] CI passes

