### PR TITLE
Bump CAPI models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ releaseProcess := Seq[ReleaseStep](
 val jacksonVersion = "2.17.2"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "content-api-models-scala" % "44.0.0",
+  "com.gu" %% "content-api-models-scala" % "46.0.0",
   "com.gu" %% "thrift-serializer" % "5.0.7",
   "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.6",


### PR DESCRIPTION
Authored by @andrewHEguardian on his cursed branch: https://github.com/guardian/content-api-firehose-client/pull/116

## What does this change?

Bumps CAPI models after the addition of the product summary element. 
Required otherwise Apple news has a binary incompatibility issue https://github.com/guardian/apple-news/pull/729